### PR TITLE
修复安卓无法连接信道服务的问题

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -153,7 +153,7 @@ function Tunnel(serviceUrl) {
             url: serviceUrl,
             method: 'GET',
             success: function (response) {
-                if (response.statusCode === 200 && response.data && response.data.url) {
+                if (+response.statusCode === 200 && response.data && response.data.url) {
                     openSocket(me.socketUrl = response.data.url);
                 } else {
                     dispatchConnectServiceError(response);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qcloud-weapp-client-sdk",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "QCloud 微信小程序客户端 SDK",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## 问题说明

收到部分用户反馈，安卓机型连接信道服务失败，错误代码 `1001`。而在开发者工具和 IOS 上均无此问题。

## 原因分析

经过定位和分析，发现原因是下面这行代码导致的：

![image](https://cloud.githubusercontent.com/assets/1901286/21601993/ac3d27ce-d1ca-11e6-9db8-8312bd99b60e.png)

在 IOS 和开发者工具中，请求成功时返回码 `statusCode` 为数字 `200`，而在安卓返回为字符串 `"200"`，不是严格相等，所以有此问题。

## 解决方案

对比前已经强制转为数字。

对于已经在使用的开发者，有两个升级渠道：

1. 有安装 bower 的开发者，可以直接使用 `bower update` 来更新 SDK
2. 手动下载 [tunnel.js](https://raw.githubusercontent.com/tencentyun/wafer-client-sdk/master/lib/tunnel.js) 并替换开发目录中的 `vendor/qcloud-weapp-client-sdk/lib/tunnel.js`